### PR TITLE
Hopefully fix .lock

### DIFF
--- a/cogs/lockdown.py
+++ b/cogs/lockdown.py
@@ -36,12 +36,11 @@ class Lockdown(Cog):
             channel = ctx.channel
         log_channel = self.bot.get_channel(config.log_channel)
 
+        roles = config.lockdown_configs["default"]["roles"]
+
         for key, lockdown_conf in config.lockdown_configs.items():
             if channel.id in lockdown_conf["channels"]:
                 roles = lockdown_conf["roles"]
-
-        if roles is None:
-            roles = config.lockdown_configs["default"]["roles"]
 
         for role in roles:
             await self.set_sendmessage(channel, role, False, ctx.author)


### PR DESCRIPTION
If the channel isn't in the config, it would error because the `roles` variable wouldn't be set, which I think was attempting to be checked by `if roles is None:` but that still requires the `roles` variable to be set.

This PR just makes it so the `roles` variable is always set to the default before the for loop that checks for channel-specific stuff.