### PR TITLE
Add support for privileged intents

### DIFF
--- a/Robocop.py
+++ b/Robocop.py
@@ -64,8 +64,12 @@ initial_extensions = ['cogs.common',
                       'cogs.meme',
                       'cogs.uwu']
 
-bot = commands.Bot(command_prefix=get_prefix,
-                   description=config.bot_description, pm_help=True)
+intents = discord.Intents.default()
+intents.typing = False
+intents.members = True
+
+bot = commands.Bot(command_prefix=get_prefix, pm_help=True,
+                   description=config.bot_description, intents=intents)
 
 bot.log = log
 bot.loop = asyncio.get_event_loop()

--- a/cogs/mod_userlog.py
+++ b/cogs/mod_userlog.py
@@ -212,7 +212,6 @@ class ModUserlog(Cog):
                        f"created_at = {user.created_at}\n"
                        f"display_name = {user.display_name}\n"
                        f"joined_at = {user.joined_at}\n"
-                       f"activities = `{user.activities}`\n"
                        f"color = {user.colour}\n"
                        f"top_role = {role}\n",
                        embed=embed)


### PR DESCRIPTION
This PR adds support for intents, enables "Server Members" Privileged Intent, and drops requirement of "Presence" Privileged Intent. This is needed to keep role-based actions (which is a lot for a moderation bot) running.

- You will need to update to discord.py 1.5.0 or higher (`pip3 install -U discord.py`)
- You will need to enable the "Server Members" privileged intent: https://discordpy.readthedocs.io/en/latest/intents.html?highlight=intents#privileged-intents

This is a little urgent as discord will be changing default intents on [October 7, 2020](https://support.discord.com/hc/en-us/articles/360040720412#privileged-intent-whitelisting). ID verification is not needed as the bot will only be in one server, not 100+. Sorry for being so late about this, but discord.py [only added support this Tuesday with 1.5.0](https://discordpy.readthedocs.io/en/latest/whats_new.html#v1-5-0).